### PR TITLE
feat: display unsupported network alert

### DIFF
--- a/apps/mstable/i18n/en.json
+++ b/apps/mstable/i18n/en.json
@@ -491,6 +491,9 @@
   "n9CFUs": {
     "defaultMessage": "Token Approval"
   },
+  "obSWjR": {
+    "defaultMessage": "Please switch your wallet network to {name} to interact with {symbol} vault."
+  },
   "pWv8jk": {
     "defaultMessage": "Entry Fee"
   },

--- a/apps/mstable/src/assets/lang/en.json
+++ b/apps/mstable/src/assets/lang/en.json
@@ -1300,6 +1300,28 @@
       "value": "Token Approval"
     }
   ],
+  "obSWjR": [
+    {
+      "type": 0,
+      "value": "Please switch your wallet network to "
+    },
+    {
+      "type": 1,
+      "value": "name"
+    },
+    {
+      "type": 0,
+      "value": " to interact with "
+    },
+    {
+      "type": 1,
+      "value": "symbol"
+    },
+    {
+      "type": 0,
+      "value": " vault."
+    }
+  ],
   "ovJ26C": [
     {
       "type": 0,

--- a/apps/mstable/src/components/App/index.tsx
+++ b/apps/mstable/src/components/App/index.tsx
@@ -3,17 +3,14 @@ import { ErrorBoundary, ErrorPage, SunsetBanner } from '@frontend/shared-ui';
 import { Box, Stack } from '@mui/material';
 import { Outlet } from '@tanstack/react-location';
 import { useEffectOnce } from 'react-use';
-import { useNetwork } from 'wagmi';
 
 import { registerCharts } from '../../clients';
 import { GradientBackground } from '../Backgrounds';
-import { WrongNetworkPage } from '../Errors';
 import { Footer } from '../Footer';
 import { Topnav } from '../Topnav';
 
 export const App = () => {
   const track = useTrack();
-  const { chain } = useNetwork();
 
   useEffectOnce(() => {
     registerCharts();
@@ -52,7 +49,7 @@ export const App = () => {
         >
           <Box minHeight="80vh" pt={{ xs: 2, md: 5 }}>
             <SunsetBanner borderRadius={3} my={4} />
-            {chain?.unsupported ? <WrongNetworkPage /> : <Outlet />}
+            <Outlet />
           </Box>
           <Footer py={4} />
         </GradientBackground>

--- a/libs/mstable/vault/src/components/NetworkAlert/index.tsx
+++ b/libs/mstable/vault/src/components/NetworkAlert/index.tsx
@@ -4,7 +4,10 @@ import { useIntl } from 'react-intl';
 
 import type { PoolConfig } from '@dhedge/core-ui-kit/types';
 
-export const NetworkAlert = ({ chainId }: Pick<PoolConfig, 'chainId'>) => {
+export const NetworkAlert = ({
+  chainId,
+  symbol,
+}: Pick<PoolConfig, 'chainId' | 'symbol'>) => {
   const intl = useIntl();
 
   const { chainId: walletChainId, chains, switchNetwork } = useNetwork();
@@ -40,10 +43,17 @@ export const NetworkAlert = ({ chainId }: Pick<PoolConfig, 'chainId'>) => {
         </Button>
       }
     >
-      {intl.formatMessage({
-        defaultMessage: 'Unsupported Network',
-        id: 'PmkP1H',
-      })}
+      {intl.formatMessage(
+        {
+          defaultMessage:
+            'Please switch your wallet network to {name} to interact with {symbol} vault.',
+          id: 'obSWjR',
+        },
+        {
+          name,
+          symbol,
+        },
+      )}
     </Alert>
   );
 };

--- a/libs/mstable/vault/src/components/NetworkAlert/index.tsx
+++ b/libs/mstable/vault/src/components/NetworkAlert/index.tsx
@@ -7,10 +7,10 @@ import type { PoolConfig } from '@dhedge/core-ui-kit/types';
 export const NetworkAlert = ({ chainId }: Pick<PoolConfig, 'chainId'>) => {
   const intl = useIntl();
 
-  const { chain, chains, switchNetwork } = useNetwork();
+  const { chainId: walletChainId, chains, switchNetwork } = useNetwork();
   const { name } = chains.find(({ id }) => id === chainId) ?? { name: chainId };
 
-  if (!chain.unsupported) {
+  if (walletChainId === chainId) {
     return null;
   }
 

--- a/libs/mstable/vault/src/components/NetworkAlert/index.tsx
+++ b/libs/mstable/vault/src/components/NetworkAlert/index.tsx
@@ -1,0 +1,49 @@
+import { useNetwork } from '@dhedge/core-ui-kit/hooks/web3';
+import { Alert, Button } from '@mui/material';
+import { useIntl } from 'react-intl';
+
+import type { PoolConfig } from '@dhedge/core-ui-kit/types';
+
+export const NetworkAlert = ({ chainId }: Pick<PoolConfig, 'chainId'>) => {
+  const intl = useIntl();
+
+  const { chain, chains, switchNetwork } = useNetwork();
+  const { name } = chains.find(({ id }) => id === chainId) ?? { name: chainId };
+
+  if (!chain.unsupported) {
+    return null;
+  }
+
+  return (
+    <Alert
+      severity="warning"
+      sx={{
+        width: '100%',
+        mb: 2,
+        '.MuiAlert-icon': {
+          svg: {
+            height: 34,
+          },
+        },
+      }}
+      action={
+        <Button
+          variant="contained"
+          color="secondary"
+          size="small"
+          onClick={() => switchNetwork(chainId)}
+        >
+          {intl.formatMessage(
+            { defaultMessage: 'Switch to {defaultChain}', id: '1XVJUl' },
+            { defaultChain: name },
+          )}
+        </Button>
+      }
+    >
+      {intl.formatMessage({
+        defaultMessage: 'Unsupported Network',
+        id: 'PmkP1H',
+      })}
+    </Alert>
+  );
+};

--- a/libs/mstable/vault/src/views/Vault.tsx
+++ b/libs/mstable/vault/src/views/Vault.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from '@tanstack/react-location';
 import { ArrowLeft } from 'phosphor-react';
 import { useIntl } from 'react-intl';
 
+import { NetworkAlert } from '../components/NetworkAlert';
 import { Position } from '../components/Position';
 import { Strategy } from '../components/Strategy';
 import { TradingPanel } from '../components/TradingPanel';
@@ -32,6 +33,7 @@ const VaultContent = ({ config, ...props }: VaultProps) => {
 
   return (
     <Stack direction="column" alignItems="flex-start" {...props}>
+      <NetworkAlert chainId={config.chainId} />
       <Button
         variant="text"
         size="small"

--- a/libs/mstable/vault/src/views/Vault.tsx
+++ b/libs/mstable/vault/src/views/Vault.tsx
@@ -33,7 +33,7 @@ const VaultContent = ({ config, ...props }: VaultProps) => {
 
   return (
     <Stack direction="column" alignItems="flex-start" {...props}>
-      <NetworkAlert chainId={config.chainId} />
+      <NetworkAlert chainId={config.chainId} symbol={config.symbol} />
       <Button
         variant="text"
         size="small"


### PR DESCRIPTION
Removes global unsupported network error page.
Adds wrong network alert + switch action button.

<img width="1222" alt="Screenshot 2023-06-05 at 23 04 18" src="https://github.com/mstable/frontend/assets/26701134/db6e9df5-607b-4ba6-95e6-ba8ca8655a7c">


