### PR TITLE
feat: add pnl in terms of ETH for ETHy vault

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,40 @@
+## Issue
+
+Link to Trello card
+
+## Description
+
+What this does and why it's needed, goals of the pull request's commits
+
+## Verifying
+
+How to confirm changes, and explain how this was tested
+
+_Steps to verify_
+
+_Expected results_
+
+## Implementation details
+
+Highlights of how the implementation fixes the issue or anything relevant about a new feature
+
+## Screenshots
+
+### Before
+
+### After
+
+## Related PRs
+
+List related PRs against other branches:
+
+| Short identifier    | Source                  |
+| ------------------- | ----------------------- |
+| back-end-related-pr | [link](paste-link-here) |
+| some-other_pr       | [link](paste-link-here) |
+
+## Todos (if a PR is in work in progress state)
+
+- [ ] Tests
+- [ ] Documentation
+- [ ] Other things can be put here

--- a/libs/mstable/explore/src/components/CoreVaultCard/components/DefaultVaultCard.tsx
+++ b/libs/mstable/explore/src/components/CoreVaultCard/components/DefaultVaultCard.tsx
@@ -30,7 +30,7 @@ export const DefaultVaultCard = (props: CoreVaultCardProps) => {
     balance,
     balanceLabel,
     balanceHint,
-    formattedRoiUsd,
+    roiInfo,
     roiLabel,
   } = useCoreVaultCardProps(props);
   const { config, to, ...rest } = props;
@@ -142,27 +142,89 @@ export const DefaultVaultCard = (props: CoreVaultCardProps) => {
               label: { sx: { mb: 0.5 } },
             }}
           >
-            {isLoading ? (
+            {roiInfo.isRoiLoading ? (
               <Skeleton width={50} />
             ) : (
-              <Typography
-                variant="value3"
-                color={
-                  formattedRoiUsd === 0
-                    ? undefined
-                    : formattedRoiUsd > 0
-                    ? 'success.main'
-                    : 'error.main'
-                }
-              >
-                {Intl.NumberFormat('en-US', {
-                  currency: 'USD',
-                  style: 'currency',
-                  maximumSignificantDigits: 2,
-                }).format(formattedRoiUsd)}
-              </Typography>
+              <>
+                <Typography
+                  variant={roiInfo.customRoiInCurrency ? 'value4' : 'value3'}
+                  color={
+                    roiInfo.roiInUsd === 0
+                      ? undefined
+                      : roiInfo.roiInUsd > 0
+                      ? 'success.main'
+                      : 'error.main'
+                  }
+                >
+                  {Intl.NumberFormat('en-US', {
+                    currency: 'USD',
+                    style: 'currency',
+                    maximumSignificantDigits: 3,
+                  }).format(roiInfo.roiInUsd)}
+                </Typography>
+                {roiInfo.roiInUsd !== 0 && (
+                  <Typography
+                    variant="value5"
+                    color={
+                      roiInfo.roiInPercentage === 0
+                        ? undefined
+                        : roiInfo.roiInPercentage > 0
+                        ? 'success.main'
+                        : 'error.main'
+                    }
+                    ml={0.5}
+                  >
+                    (
+                    {Intl.NumberFormat('en-US', {
+                      style: 'percent',
+                      maximumSignificantDigits: 2,
+                    }).format(roiInfo.roiInPercentage / 100)}
+                    )
+                  </Typography>
+                )}
+              </>
             )}
           </ValueLabel>
+          {!!roiInfo.customRoiInCurrency &&
+            !!roiInfo.customRoiCurrencySymbol && (
+              <Stack direction="row" alignItems="center" mt={-0.5}>
+                <Typography
+                  variant="value4"
+                  color={
+                    roiInfo.customRoiInCurrency === 0
+                      ? undefined
+                      : roiInfo.customRoiInCurrency > 0
+                      ? 'success.main'
+                      : 'error.main'
+                  }
+                >
+                  {Intl.NumberFormat('en-US', {
+                    currency: 'USD',
+                    style: 'currency',
+                    maximumFractionDigits: 3,
+                  })
+                    .format(roiInfo.customRoiInCurrency)
+                    .replace('$', roiInfo.customRoiCurrencySymbol)}
+                </Typography>
+                <Typography
+                  variant="value5"
+                  color={
+                    roiInfo.customRoiInPercentage === 0
+                      ? undefined
+                      : roiInfo.customRoiInPercentage > 0
+                      ? 'success.main'
+                      : 'error.main'
+                  }
+                >
+                  (
+                  {Intl.NumberFormat('en-US', {
+                    style: 'percent',
+                    maximumSignificantDigits: 2,
+                  }).format(roiInfo.customRoiInPercentage / 100)}
+                  )
+                </Typography>
+              </Stack>
+            )}
         </Grid2>
       </Grid2>
     </HoverablePrimaryCard>

--- a/libs/mstable/explore/src/components/CoreVaultCard/components/MobileVaultCard.tsx
+++ b/libs/mstable/explore/src/components/CoreVaultCard/components/MobileVaultCard.tsx
@@ -31,7 +31,7 @@ export const MobileVaultCard = (props: CoreVaultCardProps) => {
     balanceLabel,
     balanceHint,
     roiLabel,
-    formattedRoiUsd,
+    roiInfo,
   } = useCoreVaultCardProps(props);
   const { config, to, ...rest } = props;
 
@@ -115,27 +115,94 @@ export const MobileVaultCard = (props: CoreVaultCardProps) => {
               label: { sx: { mb: 0.5 } },
             }}
           >
-            {isLoading ? (
+            {roiInfo.isRoiLoading ? (
               <Skeleton width={50} />
             ) : (
-              <Typography
-                variant="value3"
-                color={
-                  formattedRoiUsd === 0
-                    ? undefined
-                    : formattedRoiUsd > 0
-                    ? 'success.main'
-                    : 'error.main'
-                }
-              >
-                {Intl.NumberFormat('en-US', {
-                  currency: 'USD',
-                  style: 'currency',
-                  maximumSignificantDigits: 2,
-                }).format(formattedRoiUsd)}
-              </Typography>
+              <>
+                <Typography
+                  variant="value3"
+                  color={
+                    !roiInfo.roiInUsd
+                      ? undefined
+                      : roiInfo.roiInUsd > 0
+                      ? 'success.main'
+                      : 'error.main'
+                  }
+                >
+                  {Intl.NumberFormat('en-US', {
+                    currency: 'USD',
+                    style: 'currency',
+                    maximumSignificantDigits: 2,
+                  }).format(roiInfo.roiInUsd)}
+                </Typography>
+                {roiInfo.roiInUsd !== 0 && (
+                  <Typography
+                    variant="value5"
+                    color={
+                      roiInfo.roiInPercentage === 0
+                        ? undefined
+                        : roiInfo.roiInPercentage > 0
+                        ? 'success.main'
+                        : 'error.main'
+                    }
+                    ml={0.5}
+                  >
+                    (
+                    {Intl.NumberFormat('en-US', {
+                      style: 'percent',
+                      maximumSignificantDigits: 2,
+                    }).format(roiInfo.roiInPercentage / 100)}
+                    )
+                  </Typography>
+                )}
+              </>
             )}
           </ValueLabel>
+          {!!roiInfo.customRoiInCurrency &&
+            !!roiInfo.customRoiCurrencySymbol && (
+              <Stack
+                direction="row"
+                alignItems="center"
+                mt={-0.5}
+                sx={{ flexWrap: 'nowrap' }}
+              >
+                <Typography
+                  variant="value3"
+                  color={
+                    roiInfo.customRoiInCurrency === 0
+                      ? undefined
+                      : roiInfo.customRoiInCurrency > 0
+                      ? 'success.main'
+                      : 'error.main'
+                  }
+                >
+                  {Intl.NumberFormat('en-US', {
+                    currency: 'USD',
+                    style: 'currency',
+                    maximumFractionDigits: 3,
+                  })
+                    .format(roiInfo.customRoiInCurrency)
+                    .replace('$', roiInfo.customRoiCurrencySymbol)}
+                </Typography>
+                <Typography
+                  variant="value5"
+                  color={
+                    roiInfo.customRoiInPercentage === 0
+                      ? undefined
+                      : roiInfo.customRoiInPercentage > 0
+                      ? 'success.main'
+                      : 'error.main'
+                  }
+                >
+                  (
+                  {Intl.NumberFormat('en-US', {
+                    style: 'percent',
+                    maximumSignificantDigits: 2,
+                  }).format(roiInfo.customRoiInPercentage / 100)}
+                  )
+                </Typography>
+              </Stack>
+            )}
         </Grid>
       </Grid>
     </HoverablePrimaryCard>

--- a/libs/mstable/explore/src/components/CoreVaultCard/hooks.ts
+++ b/libs/mstable/explore/src/components/CoreVaultCard/hooks.ts
@@ -31,7 +31,7 @@ export const useCoreVaultCardProps = ({ config, to }: CoreVaultCardProps) => {
   const { balanceInUsd: balance } = useUserVaultBalance({
     address: config.address,
   });
-  const { formattedRoiUsd } = useUserVaultInvestmentInfo({
+  const roiInfo = useUserVaultInvestmentInfo({
     address: config.address,
   });
 
@@ -161,6 +161,6 @@ export const useCoreVaultCardProps = ({ config, to }: CoreVaultCardProps) => {
     balanceLabel,
     balanceHint,
     roiLabel,
-    formattedRoiUsd: +formattedRoiUsd,
+    roiInfo,
   };
 };

--- a/libs/mstable/explore/src/components/CoreVaultTableRow.tsx
+++ b/libs/mstable/explore/src/components/CoreVaultTableRow.tsx
@@ -3,11 +3,11 @@ import { useMemo } from 'react';
 import { formatToUsd } from '@dhedge/core-ui-kit/utils';
 import { useFundQuery } from '@frontend/mstable-vault';
 import {
-  useIsMobile,
   useUserVaultBalance,
   useUserVaultInvestmentInfo,
 } from '@frontend/shared-hooks';
 import { TokenIconRevamp } from '@frontend/shared-ui';
+import { formatNumberToLimitedDecimals } from '@frontend/shared-utils';
 import { Stack, TableCell, TableRow, Typography } from '@mui/material';
 import { useNavigate } from '@tanstack/react-location';
 
@@ -24,13 +24,13 @@ export const CoreVaultTableRow = ({
   to,
   isLast,
 }: VaultTableRowProps) => {
-  const isMobile = useIsMobile();
   const navigate = useNavigate();
   const { data } = useFundQuery({ address: config.address });
   const { balanceInUsd } = useUserVaultBalance({ address: config.address });
-  const { formattedRoiUsd } = useUserVaultInvestmentInfo({
-    address: config.address,
-  });
+  const { roiInUsd, customRoiInCurrency, customRoiCurrencySymbol } =
+    useUserVaultInvestmentInfo({
+      address: config.address,
+    });
 
   const apy = useMemo(() => {
     const monthlyApy = data?.fund.apy?.monthly;
@@ -56,18 +56,16 @@ export const CoreVaultTableRow = ({
       <TableCell>
         <Typography variant="value4">{data?.fund.name}</Typography>
       </TableCell>
-      {!isMobile && (
-        <TableCell>
-          <Typography variant="value4">
-            {formatToUsd({
-              value: data?.fund.totalValue ? +data?.fund.totalValue : 0,
-              maximumFractionDigits: 0,
-              minimumFractionDigits: 0,
-              normalize: true,
-            })}
-          </Typography>
-        </TableCell>
-      )}
+      <TableCell>
+        <Typography variant="value4">
+          {formatToUsd({
+            value: data?.fund.totalValue ? +data?.fund.totalValue : 0,
+            maximumFractionDigits: 0,
+            minimumFractionDigits: 0,
+            normalize: true,
+          })}
+        </Typography>
+      </TableCell>
       <TableCell>
         <Stack direction="row">
           <Typography variant="value4">{apy}</Typography>
@@ -76,22 +74,31 @@ export const CoreVaultTableRow = ({
       <TableCell>
         <Typography variant="value4">{balanceInUsd}</Typography>
       </TableCell>
-      {!isMobile && (
-        <TableCell>
+      <TableCell>
+        <Stack direction="column">
           <Typography
             variant="value4"
             color={
-              formattedRoiUsd === '0'
+              roiInUsd === 0
                 ? undefined
-                : +formattedRoiUsd > 0
+                : roiInUsd > 0
                 ? 'success.main'
                 : 'error.main'
             }
           >
-            ${formattedRoiUsd}
+            ${roiInUsd}
           </Typography>
-        </TableCell>
-      )}
+          {customRoiInCurrency && (
+            <Typography
+              variant="value4"
+              color={customRoiInCurrency > 0 ? 'success.main' : 'error.main'}
+            >
+              {customRoiCurrencySymbol}
+              {formatNumberToLimitedDecimals(customRoiInCurrency, 4)}
+            </Typography>
+          )}
+        </Stack>
+      </TableCell>
     </TableRow>
   );
 };

--- a/libs/mstable/explore/src/components/Vaults.tsx
+++ b/libs/mstable/explore/src/components/Vaults.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 
 import { VAULT_CONFIGS } from '@frontend/shared-constants';
-import { useIsMobile } from '@frontend/shared-hooks';
 import {
   Box,
   Grid,
@@ -27,7 +26,6 @@ const buildVaultPath = (address: string) => `./vault/${address}`;
 export const Vaults = () => {
   const intl = useIntl();
   const theme = useTheme();
-  const isMobile = useIsMobile();
 
   const [viewMode, setViewMode] = useState<'grid' | 'table'>('grid');
 
@@ -91,14 +89,12 @@ export const Vaults = () => {
                       id: 'g6UhRO',
                     })}
                   </TableCell>
-                  {!isMobile && (
-                    <TableCell>
-                      {intl.formatMessage({
-                        defaultMessage: 'TVL',
-                        id: 'SKB/G9',
-                      })}
-                    </TableCell>
-                  )}
+                  <TableCell>
+                    {intl.formatMessage({
+                      defaultMessage: 'TVL',
+                      id: 'SKB/G9',
+                    })}
+                  </TableCell>
                   <TableCell>
                     {intl.formatMessage({
                       defaultMessage: 'APY',
@@ -111,14 +107,12 @@ export const Vaults = () => {
                       id: 'H5+NAX',
                     })}
                   </TableCell>
-                  {!isMobile && (
-                    <TableCell>
-                      {intl.formatMessage({
-                        defaultMessage: 'P&L',
-                        id: 'Do29Mx',
-                      })}
-                    </TableCell>
-                  )}
+                  <TableCell>
+                    {intl.formatMessage({
+                      defaultMessage: 'P&L',
+                      id: 'Do29Mx',
+                    })}
+                  </TableCell>
                 </TableRow>
               </TableHead>
               <TableBody>

--- a/libs/mstable/vault/src/components/Position/index.tsx
+++ b/libs/mstable/vault/src/components/Position/index.tsx
@@ -6,6 +6,7 @@ import {
 import { CountUp } from '@frontend/shared-ui';
 import { formatNumberToLimitedDecimals } from '@frontend/shared-utils';
 import { Card, CardContent, Divider, Stack, Typography } from '@mui/material';
+import Grid2 from '@mui/material/Unstable_Grid2';
 import { useIntl } from 'react-intl';
 
 import { useVault } from '../../state';
@@ -17,7 +18,13 @@ export const Position: FC<CardProps> = (props) => {
   const { account } = useAccount();
   const { config } = useVault();
   const intl = useIntl();
-  const { formattedRoi, formattedRoiUsd } = useUserVaultInvestmentInfo({
+  const {
+    roiInPercentage,
+    roiInUsd,
+    customRoiInPercentage,
+    customRoiInCurrency,
+    customRoiCurrencySymbol,
+  } = useUserVaultInvestmentInfo({
     address: config.address,
   });
   const { balanceInUsd, balance } = useUserVaultBalance({
@@ -48,31 +55,66 @@ export const Position: FC<CardProps> = (props) => {
               id: 'rfzzi6',
             })}
           </Typography>
-          <CountUp
-            variant="value1"
-            mb={1}
-            color={
-              !!account && formattedRoiUsd !== '0'
-                ? +formattedRoiUsd > 0
-                  ? 'success.main'
-                  : 'error.main'
-                : 'text.secondary'
-            }
-            end={+formattedRoiUsd}
-            prefix={intl.formatMessage({
-              defaultMessage: '$',
-              id: 'hAz8Yo',
-            })}
-          />
-          <CountUp
-            variant="value5"
-            color="text.secondary"
-            end={+formattedRoi}
-            suffix={intl.formatMessage({
-              defaultMessage: '%',
-              id: 'kZcqo0',
-            })}
-          />
+          <Grid2 container>
+            {!!customRoiInCurrency && !!customRoiCurrencySymbol && (
+              <Grid2 xs={6} direction="column">
+                <Stack direcrion="column">
+                  <CountUp
+                    variant="value2"
+                    mb={1}
+                    color={
+                      !!account && customRoiInCurrency !== 0
+                        ? customRoiInCurrency > 0
+                          ? 'success.main'
+                          : 'error.main'
+                        : 'text.secondary'
+                    }
+                    end={customRoiInCurrency}
+                    prefix={customRoiCurrencySymbol}
+                    decimals={4}
+                  />
+                  <CountUp
+                    variant="value5"
+                    color="text.secondary"
+                    end={customRoiInPercentage}
+                    suffix={intl.formatMessage({
+                      defaultMessage: '%',
+                      id: 'kZcqo0',
+                    })}
+                  />
+                </Stack>
+              </Grid2>
+            )}
+            <Grid2 xs={customRoiInPercentage ? 6 : 12} direction="column">
+              <Stack direcrion="column">
+                <CountUp
+                  variant={customRoiInPercentage ? 'value2' : 'value1'}
+                  mb={1}
+                  color={
+                    !!account && roiInUsd !== 0
+                      ? roiInUsd > 0
+                        ? 'success.main'
+                        : 'error.main'
+                      : 'text.secondary'
+                  }
+                  end={roiInUsd}
+                  prefix={intl.formatMessage({
+                    defaultMessage: '$',
+                    id: 'hAz8Yo',
+                  })}
+                />
+                <CountUp
+                  variant="value5"
+                  color="text.secondary"
+                  end={roiInPercentage}
+                  suffix={intl.formatMessage({
+                    defaultMessage: '%',
+                    id: 'kZcqo0',
+                  })}
+                />
+              </Stack>
+            </Grid2>
+          </Grid2>
         </Stack>
       </CardContent>
     </Card>

--- a/libs/shared/constants/src/currency.ts
+++ b/libs/shared/constants/src/currency.ts
@@ -1,0 +1,5 @@
+export const CURRENCY_SYMBOL_MAP = {
+  USD: '$',
+  BTC: '₿',
+  ETH: 'Ξ',
+};

--- a/libs/shared/constants/src/index.ts
+++ b/libs/shared/constants/src/index.ts
@@ -1,5 +1,6 @@
 export * from './abis';
 export * from './contracts';
+export * from './currency';
 export * from './metavaults';
 export * from './etherscan';
 export * from './mstable';

--- a/libs/shared/hooks/src/queries/index.ts
+++ b/libs/shared/hooks/src/queries/index.ts
@@ -1,2 +1,3 @@
+export { useCustomCurrencyRoiQuery } from './useCustomCurrencyRoiQuery';
 export { useTokenPriceHistoryQuery } from './useTokenPriceHistoryQuery';
 export { useAllFundsByInvestorQuery } from './useAllFundsByInvestorQuery';

--- a/libs/shared/hooks/src/queries/useCustomCurrencyRoiQuery.ts
+++ b/libs/shared/hooks/src/queries/useCustomCurrencyRoiQuery.ts
@@ -1,0 +1,45 @@
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { fetcher } from '../fetcher';
+import { dHedgeApiEndpoint } from '@frontend/shared-constants';
+
+interface CustomCurrencyRoiVariables {
+  vaultAddress: string;
+  investorAddress: string;
+}
+
+interface CustomCurrencyRoiQuery {
+  getYieldPnl: {
+    fundAddress: string;
+    investorAddress: string;
+    yieldBaseAssetPnl: number;
+    yieldPercentagePnl: number;
+    baseAssetName: string;
+  } | null;
+}
+
+const customCurrencyRoiQueryDocument = `
+  query GetYieldPnl($vaultAddress: String!, $investorAddress: String!) {
+    getYieldPnl(fundAddress: $vaultAddress, investorAddress: $investorAddress) {
+      investorAddress
+      fundAddress
+      yieldPercentagePnl
+      yieldBaseAssetPnl
+      baseAssetName
+    }
+  }
+`;
+
+export const useCustomCurrencyRoiQuery = (
+  variables: CustomCurrencyRoiVariables,
+  options?: UseQueryOptions<CustomCurrencyRoiQuery, Error>,
+) =>
+  useQuery<CustomCurrencyRoiQuery, Error>(
+    ['getYieldPnl', variables.vaultAddress, variables.investorAddress],
+    fetcher<CustomCurrencyRoiQuery, CustomCurrencyRoiVariables>(
+      dHedgeApiEndpoint,
+      {},
+      customCurrencyRoiQueryDocument,
+      variables,
+    ),
+    options,
+  );

--- a/libs/shared/hooks/src/user/useUserVaultInvestmentInfo.ts
+++ b/libs/shared/hooks/src/user/useUserVaultInvestmentInfo.ts
@@ -32,7 +32,7 @@ export const useUserVaultInvestmentInfo = ({
         vaultAddress: address,
         investorAddress: account,
       },
-      { enabled: !!account },
+      { enabled: false }, // TODO: enable custom currency roi when it will be ready
     );
 
   return {

--- a/libs/shared/hooks/src/user/useUserVaultInvestmentInfo.ts
+++ b/libs/shared/hooks/src/user/useUserVaultInvestmentInfo.ts
@@ -1,11 +1,15 @@
 import { Address } from '@dhedge/core-ui-kit/types';
 import { useAccount } from '@dhedge/core-ui-kit/hooks/web3';
-import { useAllFundsByInvestorQuery } from '../queries';
+import {
+  useAllFundsByInvestorQuery,
+  useCustomCurrencyRoiQuery,
+} from '../queries';
 import {
   formatNumberToLimitedDecimals,
   isEqualAddresses,
 } from '@frontend/shared-utils';
 import { formatUnits } from '@dhedge/core-ui-kit/utils';
+import { CURRENCY_SYMBOL_MAP } from '@frontend/shared-constants';
 
 interface UseUserVaultInvestmentInfoConfig {
   address: Address;
@@ -15,26 +19,40 @@ export const useUserVaultInvestmentInfo = ({
   address,
 }: UseUserVaultInvestmentInfoConfig) => {
   const { account } = useAccount();
-  const { data, isLoading } = useAllFundsByInvestorQuery(
+  const { data, isLoading: isRoiLoading } = useAllFundsByInvestorQuery(
     { address: account },
     { enabled: !!account },
   );
   const returnOnInvestment = data?.allFundsByInvestor.find(({ fundAddress }) =>
     isEqualAddresses(fundAddress, address),
   );
+  const { data: customRoi, isLoading: isCustomRoiLoading } =
+    useCustomCurrencyRoiQuery(
+      {
+        vaultAddress: address,
+        investorAddress: account,
+      },
+      { enabled: !!account },
+    );
 
   return {
-    isLoading,
-    formattedRoi: returnOnInvestment?.returnOnInvestment
-      ? formatNumberToLimitedDecimals(
+    isRoiLoading: !!account && isRoiLoading,
+    isCustomRoiLoading: !!account && isCustomRoiLoading,
+    roiInPercentage: returnOnInvestment?.returnOnInvestment
+      ? +formatNumberToLimitedDecimals(
           (+formatUnits(returnOnInvestment?.returnOnInvestment) - 1) * 100,
           2,
         )
-      : '0',
-    formattedRoiUsd: returnOnInvestment?.roiUsd
-      ? formatNumberToLimitedDecimals(formatUnits(returnOnInvestment.roiUsd), 2)
-      : '0',
-    roi: returnOnInvestment?.returnOnInvestment,
-    roiUsd: returnOnInvestment?.roiUsd,
+      : 0,
+    roiInUsd: returnOnInvestment?.roiUsd
+      ? +formatNumberToLimitedDecimals(
+          formatUnits(returnOnInvestment.roiUsd),
+          2,
+        )
+      : 0,
+    customRoiInPercentage: customRoi?.getYieldPnl?.yieldPercentagePnl,
+    customRoiInCurrency: customRoi?.getYieldPnl?.yieldBaseAssetPnl,
+    customRoiCurrencySymbol:
+      CURRENCY_SYMBOL_MAP[customRoi?.getYieldPnl?.baseAssetName],
   };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9676,9 +9676,9 @@ camelcase@^6.0.0, camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001400:
-  version "1.0.30001439"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001439.tgz#ab7371faeb4adff4b74dad1718a6fd122e45d9cb"
-  integrity sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A==
+  version "1.0.30001509"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001509.tgz"
+  integrity sha512-2uDDk+TRiTX5hMcUYT/7CSyzMZxjfGu0vAUjS2g0LSD8UoXOv0LtpH4LxGMemsiPq6LCVIUjNwVM0erkOkGCDA==
 
 capital-case@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
#### Trello
https://trello.com/c/g3fWyj8i/3243-profit-loss-in-eth-terms-mstable

#### Description

Added profit&loss in terms of ETH for ETHy vault.


<img width="438" alt="Screenshot 2023-06-29 at 14 06 17" src="https://github.com/mstable/frontend/assets/49659185/99ea2be1-535c-4abb-8b51-5f9a8b961336">
<img width="453" alt="Screenshot 2023-06-29 at 14 06 25" src="https://github.com/mstable/frontend/assets/49659185/43bbf65e-7a5a-4c58-b6ff-acba5c8c6d23">
