### PR TITLE
fix: funding rate display value

### DIFF
--- a/libs/mstable/flatcoin/src/components/Jumbo/index.tsx
+++ b/libs/mstable/flatcoin/src/components/Jumbo/index.tsx
@@ -47,7 +47,7 @@ const FlatcoinValues = () => {
         {!data.apy ? (
           <Skeleton height={24} width={60} />
         ) : (
-          <Typography variant="value2">{data.apy}</Typography>
+          <Typography variant="value3">{data.apy}</Typography>
         )}
       </ValueLabel>
       <ValueLabel
@@ -60,7 +60,7 @@ const FlatcoinValues = () => {
         {!data.tvl ? (
           <Skeleton height={24} width={60} />
         ) : (
-          <Typography variant="value2">{data.tvl}</Typography>
+          <Typography variant="value3">{data.tvl}</Typography>
         )}
       </ValueLabel>
     </>
@@ -88,7 +88,7 @@ const LeveragedEthValues = () => {
           <Skeleton height={24} width={60} />
         ) : (
           <Typography
-            variant="value2"
+            variant="value3"
             color={resolveColor(data.fundingRate.simple)}
           >
             {formatNumberToLimitedDecimals(data.fundingRate.simple, 6)}%

--- a/libs/mstable/flatcoin/src/state.ts
+++ b/libs/mstable/flatcoin/src/state.ts
@@ -202,7 +202,11 @@ export const {
           : BigDecimal.ZERO;
 
         draft.data.fundingRate = contractData[9]
-          ? new BigDecimal(contractData[9].toString())
+          ? new BigDecimal(
+              new BigNumber(contractData[9].toString())
+                .multipliedBy(100)
+                .toString(),
+            )
           : BigDecimal.ZERO;
 
         draft.data.openInterest = contractData[8]


### PR DESCRIPTION
## Issue

Link to Trello card

## Description

Initial fundingRate contract values is multiplied by 100 to display on UI.
Aligns font size for jumbo items.

## Verifying

How to confirm changes, and explain how this was tested

_Steps to verify_

_Expected results_

## Implementation details

Highlights of how the implementation fixes the issue or anything relevant about a new feature

## Screenshots

### Before

### After

## Related PRs

List related PRs against other branches:

| Short identifier    | Source                  |
| ------------------- | ----------------------- |
| back-end-related-pr | [link](paste-link-here) |
| some-other_pr       | [link](paste-link-here) |

## Todos (if a PR is in work in progress state)

- [ ] Tests
- [ ] Documentation
- [ ] Other things can be put here
