### PR TITLE
Feat/order execution notification

### DIFF
--- a/apps/mstable/src/components/Topnav/index.tsx
+++ b/apps/mstable/src/components/Topnav/index.tsx
@@ -39,7 +39,7 @@ export const Topnav = () => {
         }}
       >
         {wide && (
-          <Typography variant="h3" sx={{ 'pointer-events': 'none' }}>
+          <Typography variant="h3" sx={{ pointerEvents: 'none' }}>
             Flatcoin
           </Typography>
         )}

--- a/libs/mstable/flatcoin/src/components/MobileBottomCard/index.tsx
+++ b/libs/mstable/flatcoin/src/components/MobileBottomCard/index.tsx
@@ -1,0 +1,97 @@
+import { useState } from 'react';
+
+import { CollapsibleSection, Dialog } from '@frontend/shared-ui';
+import { Box, Button, Card } from '@mui/material';
+import { useIntl } from 'react-intl';
+
+import { useFlatcoin } from '../../state';
+import { LeveragePositionsTable } from '../Positions/Leverage/LeveragePositionsTable';
+import { StablePosition } from '../Positions/Stable';
+import { TradingPanel } from '../TradingPanel';
+
+import type { FC } from 'react';
+
+export const MobileBottomCard: FC = () => {
+  const intl = useIntl();
+  const { leveragedPositions } = useFlatcoin();
+  const [isMyPositionOpen, setIsMyPositionOpen] = useState(false);
+  const [isLeveragedPositionsOpen, setIsLeveragedPositionsOpen] =
+    useState(false);
+  const [isTradingOpen, setIsTradingOpen] = useState(false);
+
+  return (
+    <>
+      <Card sx={{ position: 'fixed', bottom: 0, left: 0, right: 0, zIndex: 1 }}>
+        <Box
+          m={2}
+          pb={1}
+          borderBottom={(theme) => `1px solid ${theme.palette.divider}`}
+        >
+          <CollapsibleSection
+            iconPosition="end"
+            title={intl.formatMessage({
+              defaultMessage: 'My Position',
+              id: '0NMLMN',
+            })}
+            components={{
+              title: { sx: { typography: 'body1' } },
+            }}
+            open={isMyPositionOpen}
+            onToggle={() => setIsMyPositionOpen((o) => !o)}
+          >
+            <StablePosition />
+          </CollapsibleSection>
+        </Box>
+        {!!leveragedPositions.length && (
+          <Box
+            m={2}
+            pb={1}
+            borderBottom={(theme) => `1px solid ${theme.palette.divider}`}
+          >
+            <CollapsibleSection
+              iconPosition="end"
+              title={intl.formatMessage({
+                defaultMessage: 'Leveraged Positions',
+                id: 'AlCWDq',
+              })}
+              components={{
+                title: { sx: { typography: 'body1' } },
+              }}
+              open={isLeveragedPositionsOpen}
+              onToggle={() => setIsLeveragedPositionsOpen((o) => !o)}
+            >
+              <LeveragePositionsTable />
+            </CollapsibleSection>
+          </Box>
+        )}
+        <Box m={2} mt={3}>
+          <Button fullWidth onClick={() => setIsTradingOpen(true)}>
+            {intl.formatMessage({
+              defaultMessage: 'Trading',
+              id: 'NpWjvV',
+            })}
+          </Button>
+        </Box>
+      </Card>
+      <Dialog
+        open={isTradingOpen}
+        onClose={() => setIsTradingOpen(false)}
+        title={intl.formatMessage({
+          defaultMessage: 'Trading',
+          id: 'NpWjvV',
+        })}
+        content={
+          <TradingPanel
+            elevation={0}
+            sx={{
+              backgroundColor: 'transparent',
+              mt: 2,
+              border: 'none',
+              boxShadow: 0,
+            }}
+          />
+        }
+      />
+    </>
+  );
+};

--- a/libs/mstable/flatcoin/src/components/Positions/Leverage/CloseLeveragePositionModal.tsx
+++ b/libs/mstable/flatcoin/src/components/Positions/Leverage/CloseLeveragePositionModal.tsx
@@ -13,6 +13,7 @@ import {
 import {
   BigDecimal,
   formatNumberToLimitedDecimals,
+  getColorFromValue,
   isEqualAddresses,
 } from '@frontend/shared-utils';
 import { Button, Divider, Stack, Typography } from '@mui/material';
@@ -104,11 +105,7 @@ const useCloseLeveragePositionModal = ({
       style: 'decimal',
       maximumFractionDigits: DEFAULT_TOKEN_DECIMALS,
     }).format(profitLoss.simple),
-    profitLossTextColor: !profitLoss.exact.isZero()
-      ? profitLoss.exact.gt(0)
-        ? 'success.main'
-        : 'error.main'
-      : 'text.secondary',
+    profitLossTextColor: getColorFromValue({ value: profitLoss }),
     refetch,
   };
 };

--- a/libs/mstable/flatcoin/src/components/Positions/Leverage/LeveragePositionsTable.tsx
+++ b/libs/mstable/flatcoin/src/components/Positions/Leverage/LeveragePositionsTable.tsx
@@ -1,0 +1,144 @@
+import { formatToUsd } from '@dhedge/core-ui-kit/utils';
+import { DEFAULT_TOKEN_DECIMALS } from '@frontend/shared-constants';
+import { TokenIconRevamp } from '@frontend/shared-ui';
+import { formatNumberToLimitedDecimals } from '@frontend/shared-utils';
+import {
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
+import { useIntl } from 'react-intl';
+
+import { useFlatcoin } from '../../../state';
+import { CloseLeveragePositionModal } from './CloseLeveragePositionModal';
+
+import type { FC } from 'react';
+
+import type { LeveragedPosition } from '../../../types';
+
+const PositionsTableRow: FC<{ position: LeveragedPosition }> = ({
+  position,
+}) => {
+  const {
+    tokens: { collateral },
+  } = useFlatcoin();
+  const { marginDeposited, leverage, entryPrice, profitLoss } = position;
+  const marginDepositedInUsd = marginDeposited.simple * entryPrice.simple;
+  const profitLossInUsd = profitLoss.simple * collateral.price.simple;
+  const isPositiveProfit = profitLoss.exact.gt(0);
+  return (
+    <TableRow>
+      <TableCell>
+        <Stack direction="row" alignItems="center" spacing={0.5}>
+          <Typography variant="value5">
+            {formatNumberToLimitedDecimals(
+              marginDeposited.simple,
+              DEFAULT_TOKEN_DECIMALS,
+            )}
+          </Typography>
+          <TokenIconRevamp
+            sx={{ width: 12, height: 12, ml: 0.5 }}
+            symbols={[collateral.symbol]}
+          />
+          <Typography variant="value5">{collateral.symbol}</Typography>
+        </Stack>
+        <Typography variant="value6" color="text.secondary">
+          ≈{formatToUsd({ value: marginDepositedInUsd })}
+        </Typography>
+      </TableCell>
+      <TableCell>
+        <Typography variant="value5">
+          {formatNumberToLimitedDecimals(leverage, 2)}X
+        </Typography>
+      </TableCell>
+      <TableCell>
+        <Typography variant="value5">
+          {formatToUsd({ value: entryPrice.simple })}
+        </Typography>
+      </TableCell>
+      <TableCell>
+        <Stack direction="row" alignItems="center" spacing={0.5}>
+          <Typography
+            variant="value5"
+            color={
+              !profitLoss.exact.isZero()
+                ? isPositiveProfit
+                  ? 'success.main'
+                  : 'error.main'
+                : 'text.secondary'
+            }
+          >
+            {isPositiveProfit && '+'}
+            {formatNumberToLimitedDecimals(
+              profitLoss.simple,
+              DEFAULT_TOKEN_DECIMALS,
+            )}{' '}
+          </Typography>
+          <TokenIconRevamp
+            sx={{ width: 12, height: 12, ml: 0.5 }}
+            symbols={[collateral.symbol]}
+          />
+          <Typography variant="value5">{collateral.symbol}</Typography>
+        </Stack>
+        <Typography variant="value6" color="text.secondary">
+          ≈{formatToUsd({ value: profitLossInUsd })}
+        </Typography>
+      </TableCell>
+      <TableCell>
+        <CloseLeveragePositionModal position={position} sx={{ minWidth: 92 }} />
+      </TableCell>
+    </TableRow>
+  );
+};
+
+export const LeveragePositionsTable: FC = () => {
+  const intl = useIntl();
+  const { leveragedPositions } = useFlatcoin();
+
+  return (
+    <TableContainer component={Paper}>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>
+              {intl.formatMessage({
+                defaultMessage: 'Margin Deposited',
+                id: 'inIeEz',
+              })}
+            </TableCell>
+            <TableCell>
+              {intl.formatMessage({
+                defaultMessage: 'Leverage',
+                id: 'pbpdV6',
+              })}
+            </TableCell>
+            <TableCell>
+              {intl.formatMessage({
+                defaultMessage: 'Entry Price',
+                id: 'Ty3dr6',
+              })}
+            </TableCell>
+            <TableCell>
+              {intl.formatMessage({
+                defaultMessage: 'Profit/Loss',
+                id: 'rfzzi6',
+              })}
+            </TableCell>
+            <TableCell />
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {leveragedPositions.map((position) => (
+            <PositionsTableRow position={position} key={position.positionId} />
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+};

--- a/libs/mstable/flatcoin/src/components/Positions/Leverage/LeveragePositionsTable.tsx
+++ b/libs/mstable/flatcoin/src/components/Positions/Leverage/LeveragePositionsTable.tsx
@@ -1,7 +1,10 @@
 import { formatToUsd } from '@dhedge/core-ui-kit/utils';
 import { DEFAULT_TOKEN_DECIMALS } from '@frontend/shared-constants';
 import { TokenIconRevamp } from '@frontend/shared-ui';
-import { formatNumberToLimitedDecimals } from '@frontend/shared-utils';
+import {
+  formatNumberToLimitedDecimals,
+  getColorFromValue,
+} from '@frontend/shared-utils';
 import {
   Paper,
   Stack,
@@ -31,7 +34,6 @@ const PositionsTableRow: FC<{ position: LeveragedPosition }> = ({
   const { marginDeposited, leverage, entryPrice, profitLoss } = position;
   const marginDepositedInUsd = marginDeposited.simple * entryPrice.simple;
   const profitLossInUsd = profitLoss.simple * collateral.price.simple;
-  const isPositiveProfit = profitLoss.exact.gt(0);
   return (
     <TableRow>
       <TableCell>
@@ -66,19 +68,12 @@ const PositionsTableRow: FC<{ position: LeveragedPosition }> = ({
         <Stack direction="row" alignItems="center" spacing={0.5}>
           <Typography
             variant="value5"
-            color={
-              !profitLoss.exact.isZero()
-                ? isPositiveProfit
-                  ? 'success.main'
-                  : 'error.main'
-                : 'text.secondary'
-            }
+            color={getColorFromValue({ value: profitLoss })}
           >
-            {isPositiveProfit && '+'}
             {formatNumberToLimitedDecimals(
               profitLoss.simple,
               DEFAULT_TOKEN_DECIMALS,
-            )}{' '}
+            )}
           </Typography>
           <TokenIconRevamp
             sx={{ width: 12, height: 12, ml: 0.5 }}

--- a/libs/mstable/flatcoin/src/components/Positions/Leverage/index.tsx
+++ b/libs/mstable/flatcoin/src/components/Positions/Leverage/index.tsx
@@ -1,104 +1,13 @@
-import { formatToUsd } from '@dhedge/core-ui-kit/utils';
-import { DEFAULT_TOKEN_DECIMALS } from '@frontend/shared-constants';
-import { TokenIconRevamp } from '@frontend/shared-ui';
-import { formatNumberToLimitedDecimals } from '@frontend/shared-utils';
-import {
-  Paper,
-  Stack,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Typography,
-} from '@mui/material';
+import { Stack, Typography } from '@mui/material';
 import { useIntl } from 'react-intl';
 
 import { useFlatcoin } from '../../../state';
-import { CloseLeveragePositionModal } from './CloseLeveragePositionModal';
+import { LeveragePositionsTable } from './LeveragePositionsTable';
 
 import type { StackProps } from '@mui/material';
 import type { FC } from 'react';
 
-import type { LeveragedPosition } from '../../../types';
-
-const PositionsTableRow: FC<{ position: LeveragedPosition }> = ({
-  position,
-}) => {
-  const {
-    tokens: { collateral },
-  } = useFlatcoin();
-  const { marginDeposited, leverage, entryPrice, profitLoss } = position;
-  const marginDepositedInUsd = marginDeposited.simple * entryPrice.simple;
-  const profitLossInUsd = profitLoss.simple * collateral.price.simple;
-  const isPositiveProfit = profitLoss.exact.gt(0);
-  return (
-    <TableRow>
-      <TableCell>
-        <Stack direction="row" alignItems="center" spacing={0.5}>
-          <Typography variant="value5">
-            {formatNumberToLimitedDecimals(
-              marginDeposited.simple,
-              DEFAULT_TOKEN_DECIMALS,
-            )}
-          </Typography>
-          <TokenIconRevamp
-            sx={{ width: 12, height: 12, ml: 0.5 }}
-            symbols={[collateral.symbol]}
-          />
-          <Typography variant="value5">{collateral.symbol}</Typography>
-        </Stack>
-        <Typography variant="value6" color="text.secondary">
-          ≈{formatToUsd({ value: marginDepositedInUsd })}
-        </Typography>
-      </TableCell>
-      <TableCell>
-        <Typography variant="value5">
-          {formatNumberToLimitedDecimals(leverage, 2)}X
-        </Typography>
-      </TableCell>
-      <TableCell>
-        <Typography variant="value5">
-          {formatToUsd({ value: entryPrice.simple })}
-        </Typography>
-      </TableCell>
-      <TableCell>
-        <Stack direction="row" alignItems="center" spacing={0.5}>
-          <Typography
-            variant="value5"
-            color={
-              !profitLoss.exact.isZero()
-                ? isPositiveProfit
-                  ? 'success.main'
-                  : 'error.main'
-                : 'text.secondary'
-            }
-          >
-            {isPositiveProfit && '+'}
-            {formatNumberToLimitedDecimals(
-              profitLoss.simple,
-              DEFAULT_TOKEN_DECIMALS,
-            )}{' '}
-          </Typography>
-          <TokenIconRevamp
-            sx={{ width: 12, height: 12, ml: 0.5 }}
-            symbols={[collateral.symbol]}
-          />
-          <Typography variant="value5">{collateral.symbol}</Typography>
-        </Stack>
-        <Typography variant="value6" color="text.secondary">
-          ≈{formatToUsd({ value: profitLossInUsd })}
-        </Typography>
-      </TableCell>
-      <TableCell>
-        <CloseLeveragePositionModal position={position} sx={{ minWidth: 92 }} />
-      </TableCell>
-    </TableRow>
-  );
-};
-
-export const LeveragePositions = (props: StackProps) => {
+export const LeveragePositions: FC<StackProps> = (props) => {
   const intl = useIntl();
   const { leveragedPositions } = useFlatcoin();
 
@@ -118,47 +27,7 @@ export const LeveragePositions = (props: StackProps) => {
           id: 'AlCWDq',
         })}
       </Typography>
-      <TableContainer component={Paper}>
-        <Table>
-          <TableHead>
-            <TableRow>
-              <TableCell>
-                {intl.formatMessage({
-                  defaultMessage: 'Margin Deposited',
-                  id: 'inIeEz',
-                })}
-              </TableCell>
-              <TableCell>
-                {intl.formatMessage({
-                  defaultMessage: 'Leverage',
-                  id: 'pbpdV6',
-                })}
-              </TableCell>
-              <TableCell>
-                {intl.formatMessage({
-                  defaultMessage: 'Entry Price',
-                  id: 'Ty3dr6',
-                })}
-              </TableCell>
-              <TableCell>
-                {intl.formatMessage({
-                  defaultMessage: 'Profit/Loss',
-                  id: 'rfzzi6',
-                })}
-              </TableCell>
-              <TableCell />
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {leveragedPositions.map((position) => (
-              <PositionsTableRow
-                position={position}
-                key={position.positionId}
-              />
-            ))}
-          </TableBody>
-        </Table>
-      </TableContainer>
+      <LeveragePositionsTable />
     </Stack>
   );
 };

--- a/libs/mstable/flatcoin/src/hooks/useOrderExecutionListener.tsx
+++ b/libs/mstable/flatcoin/src/hooks/useOrderExecutionListener.tsx
@@ -1,0 +1,41 @@
+import { usePushNotification } from '@frontend/shared-providers';
+import { ViewEtherscanLink } from '@frontend/shared-ui';
+import { getBlockExplorerUrl, isEqualAddresses } from '@frontend/shared-utils';
+import { useAccount, useContractEvent, useNetwork } from 'wagmi';
+
+import { useFlatcoin } from '../state';
+import { getFlatcoinDelayedOrderContract, getOrderTypeName } from '../utils';
+
+export const useOrderExecutionListener = () => {
+  const pushNotification = usePushNotification();
+  const { address } = useAccount();
+  const { chain } = useNetwork();
+  const { flatcoinChainId } = useFlatcoin();
+  const delayedOrderContract = getFlatcoinDelayedOrderContract(flatcoinChainId);
+
+  useContractEvent({
+    address: address ? delayedOrderContract?.address : null,
+    abi: delayedOrderContract?.abi,
+    chainId: flatcoinChainId,
+    eventName: 'OrderExecuted',
+    listener(
+      account: string,
+      orderType: number,
+      _,
+      txData: { transactionHash: string },
+    ) {
+      if (isEqualAddresses(address, account)) {
+        pushNotification({
+          title: `${getOrderTypeName(orderType)} order has been executed`,
+          content: (
+            <ViewEtherscanLink
+              hash={txData?.transactionHash ?? ''}
+              blockExplorer={getBlockExplorerUrl(chain)}
+            />
+          ),
+          severity: 'success',
+        });
+      }
+    },
+  });
+};

--- a/libs/mstable/flatcoin/src/views/Flatcoin.tsx
+++ b/libs/mstable/flatcoin/src/views/Flatcoin.tsx
@@ -9,6 +9,7 @@ import { AnnouncedOrders } from '../components/Positions/AnnouncedOrders';
 import { LeveragePositions } from '../components/Positions/Leverage';
 import { StablePosition } from '../components/Positions/Stable';
 import { TradingPanel } from '../components/TradingPanel';
+import { useOrderExecutionListener } from '../hooks/useOrderExecutionListener';
 import { FlatcoinProvider } from '../state';
 
 import type { FC } from 'react';
@@ -16,6 +17,7 @@ import type { FC } from 'react';
 const FlatcoinContent: FC = () => {
   const track = useTrack();
   const isMobile = useIsMobile();
+  useOrderExecutionListener();
 
   return (
     <Stack direction="column" alignItems="flex-start">

--- a/libs/mstable/flatcoin/src/views/Flatcoin.tsx
+++ b/libs/mstable/flatcoin/src/views/Flatcoin.tsx
@@ -4,6 +4,7 @@ import { ErrorBoundary, ErrorCard } from '@frontend/shared-ui';
 import { Grid, Stack } from '@mui/material';
 
 import { Jumbo } from '../components/Jumbo';
+import { MobileBottomCard } from '../components/MobileBottomCard';
 import { Performance } from '../components/Performance';
 import { AnnouncedOrders } from '../components/Positions/AnnouncedOrders';
 import { LeveragePositions } from '../components/Positions/Leverage';
@@ -21,21 +22,14 @@ const FlatcoinContent: FC = () => {
 
   return (
     <Stack direction="column" alignItems="flex-start">
-      {/*<Button*/}
-      {/*  variant="text"*/}
-      {/*  size="small"*/}
-      {/*  onClick={() => {*/}
-      {/*    navigate({ to: '/' });*/}
-      {/*  }}*/}
-      {/*  sx={{ mb: 1 }}*/}
-      {/*>*/}
-      {/*  <Stack direction="row" alignItems="center" spacing={0.5}>*/}
-      {/*    <ArrowLeft width={16} height={16} />*/}
-      {/*    {intl.formatMessage({ defaultMessage: 'Explore', id: '7JlauX' })}*/}
-      {/*  </Stack>*/}
-      {/*</Button>*/}
       <Grid container spacing={2}>
-        <Grid item xs={12} md={8} order={{ xs: 2, md: 1 }}>
+        <Grid
+          item
+          xs={12}
+          md={8}
+          order={{ xs: 2, md: 1 }}
+          mb={{ xs: 12, md: 0 }}
+        >
           <Stack direction="column" spacing={2}>
             <ErrorBoundary
               ErrorComponent={
@@ -64,22 +58,26 @@ const FlatcoinContent: FC = () => {
             >
               <Performance />
             </ErrorBoundary>
-            <ErrorBoundary
-              ErrorComponent={
-                <ErrorCard
-                  onMount={() => {
-                    track('error', {
-                      name: 'Unhandled Error: User Positions',
-                    });
-                  }}
-                />
-              }
-            >
-              <LeveragePositions />
-            </ErrorBoundary>
+            {!isMobile && (
+              <ErrorBoundary
+                ErrorComponent={
+                  <ErrorCard
+                    onMount={() => {
+                      track('error', {
+                        name: 'Unhandled Error: User Positions',
+                      });
+                    }}
+                  />
+                }
+              >
+                <LeveragePositions />
+              </ErrorBoundary>
+            )}
           </Stack>
         </Grid>
-        {!isMobile && (
+        {isMobile ? (
+          <MobileBottomCard />
+        ) : (
           <Grid item xs={12} md={4} order={{ xs: 1, md: 2 }}>
             <ErrorBoundary
               ErrorComponent={

--- a/libs/shared/utils/src/index.ts
+++ b/libs/shared/utils/src/index.ts
@@ -12,4 +12,5 @@ export * from './random';
 export * from './tokens';
 export * from './transactionErrors';
 export * from './types';
+export * from './typography';
 export * from './web3';

--- a/libs/shared/utils/src/typography.ts
+++ b/libs/shared/utils/src/typography.ts
@@ -1,0 +1,14 @@
+import type { BigDecimal } from './BigDecimal';
+
+export const getColorFromValue = ({
+  value,
+  defaultColor = 'text.secondary',
+}: {
+  value: BigDecimal;
+  defaultColor?: string;
+}) => {
+  if (value.exact.isZero()) {
+    return defaultColor;
+  }
+  return value.exact.gt(0) ? 'success.main' : 'error.main';
+};


### PR DESCRIPTION
## Issue

Link to Trello card

## Description

1. Added notifications about executed orders
2. Added 25 secs of delay before we show `Announced Orders` section
3. Added trading panel and positions info to mobile layout

## Verifying

How to confirm changes, and explain how this was tested

_Steps to verify_

_Expected results_

## Implementation details

Highlights of how the implementation fixes the issue or anything relevant about a new feature

## Screenshots

### Before

### After

## Related PRs

List related PRs against other branches:

| Short identifier    | Source                  |
| ------------------- | ----------------------- |
| back-end-related-pr | [link](paste-link-here) |
| some-other_pr       | [link](paste-link-here) |

## Todos (if a PR is in work in progress state)

- [ ] Tests
- [ ] Documentation
- [ ] Other things can be put here
