### PR TITLE
feat: add insurance links to trading deposit panel

### DIFF
--- a/libs/mstable/vault/src/components/TradingPanel/TradingRecap/TradingTransactionOverview.tsx
+++ b/libs/mstable/vault/src/components/TradingPanel/TradingRecap/TradingTransactionOverview.tsx
@@ -14,12 +14,18 @@ import {
   useMinReceiveText,
 } from '@dhedge/core-ui-kit/hooks/trading';
 import { formatToUsd } from '@dhedge/core-ui-kit/utils';
+import { INSUR_ACE_LINK, OPEN_COVER_LINK } from '@frontend/shared-constants';
 import { useLogAnalyticsEvent } from '@frontend/shared-providers';
-import { CollapsibleSection, InfoTooltip } from '@frontend/shared-ui';
+import {
+  CollapsibleSection,
+  InfoTooltip,
+  TokenIconRevamp,
+} from '@frontend/shared-ui';
 import {
   Box,
   CircularProgress,
   Divider,
+  Link,
   Stack,
   Typography,
 } from '@mui/material';
@@ -146,6 +152,30 @@ export const TradingTransactionOverview: FC<StackProps> = (props) => {
         })}
         value={minReceivedText}
       />
+      {isDeposit && (
+        <OverviewItem
+          label="Insurance"
+          tooltipText="Deposits can be covered for certain types of hacks"
+          value={
+            <Stack direction="row" gap={1}>
+              <Link
+                href={OPEN_COVER_LINK}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <TokenIconRevamp symbols={['opencover']} />
+              </Link>
+              <Link
+                href={INSUR_ACE_LINK}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <TokenIconRevamp symbols={['insur']} />
+              </Link>
+            </Stack>
+          }
+        />
+      )}
       {showMinRecommendedSlippage && (
         <OverviewItem
           label={intl.formatMessage({

--- a/libs/shared/constants/src/core-vaults/optimism/mhrvst.ts
+++ b/libs/shared/constants/src/core-vaults/optimism/mhrvst.ts
@@ -1,4 +1,6 @@
-import { BRIDGED_USDC_OPTIMISM, optimism } from '@dhedge/core-ui-kit/const';
+import { optimism } from '@dhedge/core-ui-kit/const';
+
+import { USDC_OPTIMISM } from '../../tokens';
 
 import type { PoolConfig } from '@dhedge/core-ui-kit/types';
 
@@ -9,10 +11,10 @@ export const MHRVST_OPTIMISM: PoolConfig = {
   symbol: 'mHRVST',
   address: '0x9c6de13d4648a6789017641f6b1a025816e66228',
   depositParams: {
-    customTokens: [BRIDGED_USDC_OPTIMISM],
+    customTokens: [],
   },
   withdrawParams: {
-    customTokens: [BRIDGED_USDC_OPTIMISM],
+    customTokens: [USDC_OPTIMISM],
   },
 };
 

--- a/libs/shared/constants/src/mstable.ts
+++ b/libs/shared/constants/src/mstable.ts
@@ -7,3 +7,9 @@ export const MEDIUM = 'https://medium.com/mstable';
 export const EMAIL = 'mailto:info@mstable.org';
 export const MSTABLE_LANDING_PAGE_URL = 'https://mstable.org/';
 export const DHEDGE = 'https://dhedge.org/';
+
+export const OPEN_COVER_LINK =
+  'https://opencover.com/app/?invite=DH100K&cover=126';
+
+export const INSUR_ACE_LINK =
+  'https://app.insurace.io/Insurance/BuyCovers?referrer=212511352154979513002532245935614371628988752555';

--- a/libs/shared/constants/src/tokens/index.ts
+++ b/libs/shared/constants/src/tokens/index.ts
@@ -14,6 +14,7 @@ import { toksPolygonMumbai } from './polygonMumbai';
 
 import type { Token } from './types';
 
+export * from './optimism';
 export * from './types';
 
 export const tokens = {

--- a/libs/shared/constants/src/tokens/optimism.tsx
+++ b/libs/shared/constants/src/tokens/optimism.tsx
@@ -2,6 +2,8 @@ import { MTA, Optimism, USDC } from '@frontend/shared-icons';
 import { erc20ABI } from 'wagmi';
 import { optimism } from 'wagmi/chains';
 
+import type { TradingToken } from '@dhedge/core-ui-kit/types';
+
 import type { Token } from './types';
 
 export const toksOptimism: Token[] = [
@@ -32,3 +34,10 @@ export const toksOptimism: Token[] = [
     abi: erc20ABI,
   },
 ];
+
+export const USDC_OPTIMISM: TradingToken = {
+  address: '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85',
+  symbol: 'USDC',
+  decimals: 6,
+  value: '',
+};


### PR DESCRIPTION
## Issue

1. [Link to Trello card](https://trello.com/c/Neq84aLD/3866-show-nexus-mutual-insurance-for-dhedge-toros-and-mstable-vualt)
2. https://trello.com/c/7F9uh4YE/4111-update-meta-harvester-deposit-withdraw-asset-usdce-usdc

## Description

Adds Insurance overview item to deposit trading panel

<img width="380" alt="Screenshot 2024-05-15 at 21 39 51" src="https://github.com/mstable/frontend/assets/26701134/84c89f9a-c41c-43b5-a2cc-07a3e0a29859">


## Verifying

How to confirm changes, and explain how this was tested

_Steps to verify_

_Expected results_

## Implementation details

Highlights of how the implementation fixes the issue or anything relevant about a new feature

## Screenshots

### Before

### After

## Related PRs

List related PRs against other branches:

| Short identifier    | Source                  |
| ------------------- | ----------------------- |
| back-end-related-pr | [link](paste-link-here) |
| some-other_pr       | [link](paste-link-here) |

## Todos (if a PR is in work in progress state)

- [ ] Tests
- [ ] Documentation
- [ ] Other things can be put here
