### PR TITLE
feat(dHEDGE V1 Deprecation): display redeemed total value instead of …

### DIFF
--- a/libs/dhedge/withdraw/src/components/BurnForm/components/InputStep/components/TokenInputs.tsx
+++ b/libs/dhedge/withdraw/src/components/BurnForm/components/InputStep/components/TokenInputs.tsx
@@ -1,14 +1,21 @@
 import { TokenInput } from '@frontend/shared-ui';
-import { Box, Button, Skeleton, Stack, Typography } from '@mui/material';
+import {
+  Box,
+  type BoxProps,
+  Button,
+  Skeleton,
+  Stack,
+  Typography,
+} from '@mui/material';
 import { ArrowFatDown } from 'phosphor-react';
 import { useAccount } from 'wagmi';
 
 import { useSetL1TokenAmount } from '../../../hooks';
 import { useTrackedState } from '../../../state';
 
-import type { BoxProps } from '@mui/material';
+import type { FC } from 'react';
 
-export const TokenInputs = (props: BoxProps) => {
+export const TokenInputs: FC<BoxProps> = (props) => {
   const { isConnected } = useAccount();
   const { l1token, l2token, isLoading, isError } = useTrackedState();
   const setL1Amount = useSetL1TokenAmount();
@@ -67,8 +74,8 @@ export const TokenInputs = (props: BoxProps) => {
             Intl.NumberFormat('en-US', {
               currency: 'USD',
               style: 'currency',
-              maximumSignificantDigits: 2,
-            }).format(l1token.price)
+              maximumFractionDigits: 2,
+            }).format(l1token.price * l1token.amount.simple)
           )}
         </Typography>
         {isConnected &&
@@ -139,7 +146,8 @@ export const TokenInputs = (props: BoxProps) => {
             Intl.NumberFormat('en-US', {
               currency: 'USD',
               style: 'currency',
-            }).format(l2token.price)
+              maximumFractionDigits: 2,
+            }).format(l2token.price * l2token.amount.simple)
           )}
         </Typography>
         {isConnected && (


### PR DESCRIPTION
…token price in redeem form

## Issue

Link to Trello card

## Description

Before
<img width="770" alt="Screenshot 2024-09-26 at 12 59 42" src="https://github.com/user-attachments/assets/844ed5b3-b0e4-44e1-92ad-37c582de58bd">

After
<img width="695" alt="Screenshot 2024-09-26 at 12 59 46" src="https://github.com/user-attachments/assets/8f4f3beb-4fcf-42e9-90f1-ffe8d755fb7d">


## Verifying

How to confirm changes, and explain how this was tested

_Steps to verify_

_Expected results_

## Implementation details

Highlights of how the implementation fixes the issue or anything relevant about a new feature

## Screenshots

### Before

### After

## Related PRs

List related PRs against other branches:

| Short identifier    | Source                  |
| ------------------- | ----------------------- |
| back-end-related-pr | [link](paste-link-here) |
| some-other_pr       | [link](paste-link-here) |

## Todos (if a PR is in work in progress state)

- [ ] Tests
- [ ] Documentation
- [ ] Other things can be put here
