### PR TITLE
fix(dHEDGE V1 Deprecation): disable redeem transaction when gas price…

### DIFF
--- a/libs/dhedge/withdraw/src/components/BurnForm/components/InputStep/components/SubmitButton.tsx
+++ b/libs/dhedge/withdraw/src/components/BurnForm/components/InputStep/components/SubmitButton.tsx
@@ -31,13 +31,13 @@ export const SubmitButton = ({ disabled }: SubmitButtonProps) => {
   const { l1token, isError, reset } = useTrackedState();
   const needsApproval = useNeedsApproval();
 
-  const config = useRedeemCallConfig();
+  const { config, zeroGasFeeParams } = useRedeemCallConfig();
   const { data: submitConfig, error: estimateError } =
     usePrepareContractWrite(config);
 
   const {
     data: submitData,
-    write: submit,
+    write,
     isLoading: isWriteLoading,
     isSuccess: isWriteSuccess,
   } = useContractWrite({
@@ -102,6 +102,18 @@ export const SubmitButton = ({ disabled }: SubmitButtonProps) => {
     },
     onSettled: reset,
   });
+
+  const submit = () => {
+    if (zeroGasFeeParams) {
+      pushNotification({
+        title: 'Transaction Cancelled',
+        content: 'Gas fee is 0. Please reload the page and try again.',
+        severity: 'info',
+      });
+      return;
+    }
+    write();
+  };
 
   if (
     !l1token.amount ||

--- a/libs/dhedge/withdraw/src/hooks/useBaseFeeAndMaxFeePerGas.tsx
+++ b/libs/dhedge/withdraw/src/hooks/useBaseFeeAndMaxFeePerGas.tsx
@@ -18,8 +18,8 @@ export const useBaseFeeAndMaxFeePerGas = ({ chainId }: { chainId: number }) => {
       }
 
       const block = await provider.getBlock(blockNumber);
-      // increase base fee by 15%
-      const baseFee = block.baseFeePerGas.mul(115).div(100);
+      // increase base fee by 20%
+      const baseFee = block.baseFeePerGas.mul(120).div(100);
 
       const priorityFeePerGas = ethers.utils.parseUnits('2', 'gwei');
 

--- a/libs/dhedge/withdraw/src/hooks/useRedeemCallConfig.ts
+++ b/libs/dhedge/withdraw/src/hooks/useRedeemCallConfig.ts
@@ -31,19 +31,22 @@ export const useRedeemCallConfig = () => {
     });
     const ethValue = maxSubmissionCost.add(l2MaxFeePerGas.mul(redeemGasLimit));
     return {
-      functionName: 'redeem',
-      args: [
-        l1token.contract.address,
-        l2token.contract.address,
-        l1token.amount.exact,
-        walletAddress,
-        encodedArbAdditionalData,
-        { value: ethValue },
-      ],
-      enabled: !isError && !l1token.amount.exact.isZero() && !needsApproval,
-      address: l1ComptrollerContract.address,
-      abi: l1ComptrollerContract.abi,
-      chainId: l1ComptrollerContract.chainId,
+      config: {
+        functionName: 'redeem',
+        args: [
+          l1token.contract.address,
+          l2token.contract.address,
+          l1token.amount.exact,
+          walletAddress,
+          encodedArbAdditionalData,
+          { value: ethValue },
+        ],
+        enabled: !isError && !l1token.amount.exact.isZero() && !needsApproval,
+        address: l1ComptrollerContract.address,
+        abi: l1ComptrollerContract.abi,
+        chainId: l1ComptrollerContract.chainId,
+      },
+      zeroGasFeeParams: l1BaseFee.isZero() || l2MaxFeePerGas.isZero(),
     };
   }, [
     isError,


### PR DESCRIPTION
… is 0

## Issue

Link to Trello card

## Description

1. Check `l1baseFee` and `l2MaxFeePerGas`
2. Disabl Redeem transaction and show popup notification if any is zero
3. Increase base fee +20%

<img width="1066" alt="Screenshot 2024-09-30 at 09 36 19" src="https://github.com/user-attachments/assets/17b24cbf-ed4c-4096-94f8-abc5f60242af">


## Verifying

How to confirm changes, and explain how this was tested

_Steps to verify_

_Expected results_

## Implementation details

Highlights of how the implementation fixes the issue or anything relevant about a new feature

## Screenshots

### Before

### After

## Related PRs

List related PRs against other branches:

| Short identifier    | Source                  |
| ------------------- | ----------------------- |
| back-end-related-pr | [link](paste-link-here) |
| some-other_pr       | [link](paste-link-here) |

## Todos (if a PR is in work in progress state)

- [ ] Tests
- [ ] Documentation
- [ ] Other things can be put here
